### PR TITLE
Use marks

### DIFF
--- a/examples/centered_big.toml
+++ b/examples/centered_big.toml
@@ -8,19 +8,19 @@ split = "vertical"
 [[screen.children.children]]
 command = "alacritty --title medium-window"
 size = 60
-name = "medium-window"
+mark = "medium-window"
 
 [[screen.children.children]]
 command = "alacritty --title tiny-window"
 size = 40
-name = "tiny-window"
+mark = "tiny-window"
 
 [[screen.children]]
 command = "alacritty --title middle-panel"
 size = 50
-name = "middle-panel"
+mark = "middle-panel"
 
 [[screen.children]]
 command = "alacritty --title right-panel"
 size = 25
-name = "right-panel"
+mark = "right-panel"

--- a/poetry.lock
+++ b/poetry.lock
@@ -254,6 +254,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "isort"
 version = "5.8.0"
 description = "A Python utility / library to sort Python imports."
@@ -273,14 +281,6 @@ description = "McCabe checker, plugin for flake8"
 category = "dev"
 optional = false
 python-versions = "*"
-
-[[package]]
-name = "more-itertools"
-version = "8.7.0"
-description = "More routines for operating on iterables, beyond itertools"
-category = "dev"
-optional = false
-python-versions = ">=3.5"
 
 [[package]]
 name = "mypy"
@@ -378,24 +378,23 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "pytest"
-version = "5.4.3"
+version = "6.2.4"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [package.dependencies]
 atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
-attrs = ">=17.4.0"
+attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
-more-itertools = ">=4.0.0"
+iniconfig = "*"
 packaging = "*"
-pluggy = ">=0.12,<1.0"
-py = ">=1.5.0"
-wcwidth = "*"
+pluggy = ">=0.12,<1.0.0a1"
+py = ">=1.8.2"
+toml = "*"
 
 [package.extras]
-checkqa-mypy = ["mypy (==v0.761)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
@@ -522,18 +521,10 @@ secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "cer
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 brotli = ["brotlipy (>=0.6.0)"]
 
-[[package]]
-name = "wcwidth"
-version = "0.2.5"
-description = "Measures the displayed width of unicode strings in a terminal"
-category = "dev"
-optional = false
-python-versions = "*"
-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "d41861919b981ec7a3ef28cb934e571963b263d5c66a6afd68abfb704bc92548"
+content-hash = "8ae79fb03aed1ea0e85283469e592cd2bab36b3e46f426e862593fb677e16ed9"
 
 [metadata.files]
 appdirs = [
@@ -673,6 +664,10 @@ idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
 isort = [
     {file = "isort-5.8.0-py3-none-any.whl", hash = "sha256:2bb1680aad211e3c9944dbce1d4ba09a989f04e238296c87fe2139faa26d655d"},
     {file = "isort-5.8.0.tar.gz", hash = "sha256:0a943902919f65c5684ac4e0154b1ad4fac6dcaa5d9f3426b732f1c8b5419be6"},
@@ -680,10 +675,6 @@ isort = [
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
-]
-more-itertools = [
-    {file = "more-itertools-8.7.0.tar.gz", hash = "sha256:c5d6da9ca3ff65220c3bfd2a8db06d698f05d4d2b9be57e1deb2be5a45019713"},
-    {file = "more_itertools-8.7.0-py3-none-any.whl", hash = "sha256:5652a9ac72209ed7df8d9c15daf4e1aa0e3d2ccd3c87f8265a0673cd9cbc9ced"},
 ]
 mypy = [
     {file = "mypy-0.812-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a26f8ec704e5a7423c8824d425086705e381b4f1dfdef6e3a1edab7ba174ec49"},
@@ -746,8 +737,8 @@ pyparsing = [
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pytest = [
-    {file = "pytest-5.4.3-py3-none-any.whl", hash = "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1"},
-    {file = "pytest-5.4.3.tar.gz", hash = "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"},
+    {file = "pytest-6.2.4-py3-none-any.whl", hash = "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"},
+    {file = "pytest-6.2.4.tar.gz", hash = "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b"},
 ]
 pytest-cov = [
     {file = "pytest-cov-2.12.0.tar.gz", hash = "sha256:8535764137fecce504a49c2b742288e3d34bc09eed298ad65963616cc98fd45e"},
@@ -891,8 +882,4 @@ typing-extensions = [
 urllib3 = [
     {file = "urllib3-1.26.4-py2.py3-none-any.whl", hash = "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df"},
     {file = "urllib3-1.26.4.tar.gz", hash = "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"},
-]
-wcwidth = [
-    {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
-    {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ click = "^8.0.0"
 toml = "^0.10.2"
 
 [tool.poetry.dev-dependencies]
-pytest = "^5.2"
 coverage = {extras = ["toml"], version = "^5.5"}
 pytest-cov = "^2.12.0"
 flake8 = "^3.9.2"
@@ -24,6 +23,7 @@ flake8-bandit = "^2.1.2"
 mypy = "^0.812"
 flake8-annotations = "^2.6.2"
 codecov = "^2.1.11"
+pytest = "^6"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
@@ -53,3 +53,7 @@ profile = "google"
 [tool.poetry.scripts]
 magic-tiler = "magic_tiler.main:main"
 get-window-sizes = "magic_tiler.get_window_sizes:main"
+
+[tool.pytest.ini_options]
+addopts = "--exitfirst --verbosity=2"
+log_file_level = "DEBUG"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,12 @@ source = ["src", "*/site-packages"]
 branch = true
 source = ["magic_tiler"]
 omit = [
+    # abstract functions so we never actually call their code
     "src/magic_tiler/interfaces.py",
+    # external apis
     "src/magic_tiler/subprocess_runner.py",
     "src/magic_tiler/sway.py",
+    # top-level scripts
     "src/magic_tiler/main.py",
     "src/magic_tiler/get_window_sizes.py",
 ]

--- a/src/magic_tiler/interfaces.py
+++ b/src/magic_tiler/interfaces.py
@@ -1,26 +1,39 @@
 import abc
-from typing import Dict
+from typing import Dict, NamedTuple
+
+
+class WindowDetails(NamedTuple):
+    mark: str
+    command: str
 
 
 class TilingWindowManager(object):
     @abc.abstractmethod
-    def make_window(self, command: str) -> None:
+    def make_window(self, window_details: WindowDetails) -> None:
         pass
 
     @abc.abstractmethod
-    def make_horizontal_sibling(self, window_title_regex: str, command: str) -> None:
+    def make_horizontal_sibling(
+        self, target_window: WindowDetails, new_window: WindowDetails
+    ) -> None:
         pass
 
     @abc.abstractmethod
-    def make_vertical_sibling(self, window_title_regex: str, command: str) -> None:
+    def make_vertical_sibling(
+        self, target_window: WindowDetails, new_window: WindowDetails
+    ) -> None:
         pass
 
     @abc.abstractmethod
-    def resize_width(self, window_title_regex: str, container_percentage: int) -> None:
+    def resize_width(
+        self, target_window: WindowDetails, container_percentage: int
+    ) -> None:
         pass
 
     @abc.abstractmethod
-    def resize_height(self, window_title_regex: str, container_percentage: int) -> None:
+    def resize_height(
+        self, target_window: WindowDetails, container_percentage: int
+    ) -> None:
         pass
 
     @property

--- a/src/magic_tiler/layout.py
+++ b/src/magic_tiler/layout.py
@@ -1,4 +1,4 @@
-from typing import Dict, Set
+from typing import Dict
 
 from magic_tiler import interfaces
 
@@ -9,7 +9,7 @@ class Layout(object):
     def __init__(
         self, config_reader: interfaces.ConfigReader, layout_name: str
     ) -> None:
-        self._windows: Dict[int, Dict] = dict()
+        self._windows: Dict[str, interfaces.WindowDetails] = dict()
         try:
             config = config_reader.to_dict()[layout_name]
         except KeyError:
@@ -17,25 +17,7 @@ class Layout(object):
         self._parse_config(config)
 
     def _parse_config(self, layout_dict: Dict) -> None:
-        self._reserved_ids: Set = set()
-        self._next_window_id: int = 0
-        self._get_reserved_ids(layout_dict)
         self._parse_node(layout_dict)
-
-    def _get_reserved_ids(self, node: Dict) -> None:
-        """Recursively parse a node and its children using depth-first traversal
-        to get the user-defined IDs and reserve them.
-        """
-        if "children" in node:
-            for child_node in node["children"]:
-                self._get_reserved_ids(child_node)
-        else:  # process the node if it's a leaf
-            if "id" in node:  # custom user-defined id
-                if node["id"] in self._reserved_ids:
-                    raise KeyError(
-                        f"There are multiple windows with ID {node['id']} in your config"
-                    )
-                self._reserved_ids.add(node["id"])
 
     def _parse_node(self, node: Dict) -> None:
         """Recursively process a node and its children using depth-first traversal"""
@@ -43,13 +25,10 @@ class Layout(object):
             for child_node in node["children"]:
                 self._parse_node(child_node)
         else:  # process the node if it's a leaf
-            if "id" in node:  # custom user-defined id
-                self._windows[node["id"]] = {"command": node["command"]}
-            else:
-                while self._next_window_id in self._reserved_ids:
-                    self._next_window_id += 1
-                self._windows[self._next_window_id] = {"command": node["command"]}
-                self._next_window_id += 1
+            mark = node["mark"]
+            self._windows[mark] = interfaces.WindowDetails(
+                mark=node["mark"], command=node["command"]
+            )
 
     @property
     def windows(self) -> Dict:

--- a/src/magic_tiler/layout.py
+++ b/src/magic_tiler/layout.py
@@ -11,13 +11,10 @@ class Layout(object):
     ) -> None:
         self._windows: Dict[str, interfaces.WindowDetails] = dict()
         try:
-            config = config_reader.to_dict()[layout_name]
+            root_node = config_reader.to_dict()[layout_name]
         except KeyError:
             raise KeyError(f'Could not find layout "{layout_name}" in config')
-        self._parse_config(config)
-
-    def _parse_config(self, layout_dict: Dict) -> None:
-        self._parse_node(layout_dict)
+        self._parse_node(root_node)
 
     def _parse_node(self, node: Dict) -> None:
         """Recursively process a node and its children using depth-first traversal"""

--- a/src/magic_tiler/main.py
+++ b/src/magic_tiler/main.py
@@ -4,6 +4,7 @@ import pprint
 import click
 
 import magic_tiler
+from magic_tiler import interfaces
 from magic_tiler import subprocess_runner
 from magic_tiler import sway
 
@@ -18,11 +19,18 @@ def main() -> None:
     )
     if swaywm.num_workspace_windows > 1:
         raise RuntimeError("There are multiple windows open in the current workspace.")
-    swaywm.make_window('alacritty --title "first window"')
-    swaywm.make_horizontal_sibling("^first window$", 'alacritty --title "big boy"')
-    swaywm.resize_width("first window", 25)
-    swaywm.make_horizontal_sibling("^big boy$", 'alacritty --title "side window"')
-    swaywm.resize_width("side window", 33)
+    first_window = interfaces.WindowDetails(
+        mark="first", command='alacritty --title "first window"'
+    )
+    big = interfaces.WindowDetails(mark="big", command='alacritty --title "big boy"')
+    side_window = interfaces.WindowDetails(
+        mark="side", command='alacritty --title "side window"'
+    )
+    swaywm.make_window(first_window)
+    swaywm.make_horizontal_sibling(first_window, big)
+    swaywm.resize_width(first_window, 25)
+    swaywm.make_horizontal_sibling(big, side_window)
+    swaywm.resize_width(side_window, 33)
     window_sizes = swaywm.get_window_sizes()
     logging.info(pprint.pformat(window_sizes))
 

--- a/src/magic_tiler/tiles.py
+++ b/src/magic_tiler/tiles.py
@@ -1,6 +1,7 @@
 import math
-from typing import Dict, NamedTuple
+from typing import NamedTuple
 
+from magic_tiler import interfaces
 from magic_tiler import windows
 
 
@@ -28,16 +29,18 @@ class TileFactory(object):
         self._screen_dimensions = screen_dimensions
 
     def make_tile(
-        self, relative_width: float, relative_height: float, window_details: Dict
+        self,
+        relative_width: float,
+        relative_height: float,
+        window_details: interfaces.WindowDetails,
     ) -> Tile:
         # calculate the pixel width and height of the window and tile
         absolute_width = math.floor(relative_width * self._screen_dimensions.width)
         absolute_height = math.floor(relative_height * self._screen_dimensions.height)
         window = windows.Window(
-            id=window_details["id"],
-            command=window_details["command"],
+            command=window_details.command,
             width=absolute_width,
             height=absolute_height,
-            name=window_details["name"],
+            mark=window_details.mark,
         )
         return Tile(width=absolute_width, height=absolute_height, window=window)

--- a/src/magic_tiler/windows.py
+++ b/src/magic_tiler/windows.py
@@ -2,8 +2,7 @@ from typing import NamedTuple
 
 
 class Window(NamedTuple):
-    id: int
     command: str
     width: int
     height: int
-    name: str
+    mark: str

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -27,86 +27,69 @@ layout_test_cases = [
                 "children": [
                     {
                         "children": [
-                            {"size": 60, "command": "alacritty --title medium-window"},
-                            {"size": 40, "command": "alacritty --title tiny-window"},
+                            {
+                                "mark": "medium",
+                                "size": 60,
+                                "command": "alacritty",
+                            },
+                            {
+                                "mark": "small",
+                                "size": 40,
+                                "command": "alacritty",
+                            },
                         ],
                         "split": "vertical",
                         "size": 25,
                     },
-                    {"size": 50, "command": "alacritty --title middle-panel"},
-                    {"size": 25, "command": "alacritty --title right-panel"},
-                ],
-                "split": "horizontal",
-            }
-        },
-        expected_windows={
-            0: {"command": "alacritty --title medium-window"},
-            1: {"command": "alacritty --title tiny-window"},
-            2: {"command": "alacritty --title middle-panel"},
-            3: {"command": "alacritty --title right-panel"},
-        },
-        layout_name="screen",
-    ),
-    LayoutTestCase(
-        config={
-            "screen": {
-                "children": [
-                    {"size": 25, "command": "alacritty --title left-panel"},
-                    {"size": 50, "command": "alacritty --title middle-panel"},
-                    {"size": 25, "command": "alacritty --title right-panel"},
-                ],
-                "split": "horizontal",
-            }
-        },
-        expected_windows={
-            0: {"command": "alacritty --title left-panel"},
-            1: {"command": "alacritty --title middle-panel"},
-            2: {"command": "alacritty --title right-panel"},
-        },
-        layout_name="screen",
-    ),
-    # Automatically assign IDs only to windows that don't have their own IDs
-    LayoutTestCase(
-        config={
-            "screen": {
-                "children": [
-                    {"size": 25, "command": "alacritty --title left-panel", "id": 50},
-                    {"size": 50, "command": "alacritty --title middle-panel"},
-                    {"size": 25, "command": "alacritty --title right-panel"},
-                ],
-                "split": "horizontal",
-            }
-        },
-        expected_windows={
-            50: {"command": "alacritty --title left-panel"},
-            0: {"command": "alacritty --title middle-panel"},
-            1: {"command": "alacritty --title right-panel"},
-        },
-        layout_name="screen",
-    ),
-    # automatically assigned IDs shouldn't collide with user-defined IDs
-    # so we shouldn't tag the first window with ID 0
-    LayoutTestCase(
-        config={
-            "screen": {
-                "children": [
-                    {"size": 25, "command": "alacritty --title left-panel"},
                     {
+                        "mark": "big",
                         "size": 50,
-                        "command": "alacritty --title middle-left-panel",
-                        "id": 0,
+                        "command": "alacritty",
                     },
-                    {"size": 50, "command": "alacritty --title middle-right-panel"},
-                    {"size": 25, "command": "alacritty --title right-panel"},
+                    {
+                        "mark": "right",
+                        "size": 25,
+                        "command": "alacritty",
+                    },
                 ],
                 "split": "horizontal",
             }
         },
         expected_windows={
-            1: {"command": "alacritty --title left-panel"},
-            0: {"command": "alacritty --title middle-left-panel"},
-            2: {"command": "alacritty --title middle-right-panel"},
-            3: {"command": "alacritty --title right-panel"},
+            "medium": interfaces.WindowDetails(command="alacritty", mark="medium"),
+            "small": interfaces.WindowDetails(command="alacritty", mark="small"),
+            "big": interfaces.WindowDetails(command="alacritty", mark="big"),
+            "right": interfaces.WindowDetails(command="alacritty", mark="right"),
+        },
+        layout_name="screen",
+    ),
+    LayoutTestCase(
+        config={
+            "screen": {
+                "children": [
+                    {
+                        "mark": "left",
+                        "size": 25,
+                        "command": "alacritty",
+                    },
+                    {
+                        "mark": "center",
+                        "size": 50,
+                        "command": "alacritty",
+                    },
+                    {
+                        "mark": "right",
+                        "size": 25,
+                        "command": "alacritty",
+                    },
+                ],
+                "split": "horizontal",
+            }
+        },
+        expected_windows={
+            "left": interfaces.WindowDetails(command="alacritty", mark="left"),
+            "center": interfaces.WindowDetails(command="alacritty", mark="center"),
+            "right": interfaces.WindowDetails(command="alacritty", mark="right"),
         },
         layout_name="screen",
     ),
@@ -115,7 +98,11 @@ layout_test_cases = [
         config={
             "screen": {
                 "children": [
-                    {"size": 100, "command": "alacritty --title wrong-panel"},
+                    {
+                        "mark": "mymark",
+                        "size": 100,
+                        "command": "alacritty",
+                    },
                 ],
                 "split": "horizontal",
             },
@@ -123,21 +110,33 @@ layout_test_cases = [
                 "children": [
                     {
                         "children": [
-                            {"size": 60, "command": "alacritty --title medium-window"},
-                            {"size": 40, "command": "alacritty --title tiny-window"},
+                            {
+                                "mark": "linter",
+                                "size": 60,
+                                "command": "alacritty",
+                            },
+                            {
+                                "mark": "terminal",
+                                "size": 40,
+                                "command": "alacritty",
+                            },
                         ],
                         "split": "vertical",
                         "size": 25,
                     },
-                    {"size": 75, "command": "alacritty --title big-panel"},
+                    {
+                        "mark": "jumbo",
+                        "size": 75,
+                        "command": "alacritty",
+                    },
                 ],
                 "split": "horizontal",
             },
         },
         expected_windows={
-            0: {"command": "alacritty --title medium-window"},
-            1: {"command": "alacritty --title tiny-window"},
-            2: {"command": "alacritty --title big-panel"},
+            "linter": interfaces.WindowDetails(command="alacritty", mark="linter"),
+            "terminal": interfaces.WindowDetails(command="alacritty", mark="terminal"),
+            "jumbo": interfaces.WindowDetails(command="alacritty", mark="jumbo"),
         },
         layout_name="dev-ide",
     ),
@@ -148,26 +147,6 @@ layout_test_cases = [
 def test_layout(test_case):
     mylayout = layout.Layout(FakeConfig(test_case.config), test_case.layout_name)
     assert mylayout.windows == test_case.expected_windows
-
-
-def test_duplicate_ids_raise_exception():
-    config = {
-        "screen": {
-            "children": [
-                {"size": 25, "command": "alacritty --title left-panel", "id": 17},
-                {
-                    "size": 50,
-                    "command": "alacritty --title middle-left-panel",
-                    "id": 17,
-                },
-                {"size": 50, "command": "alacritty --title middle-right-panel"},
-                {"size": 25, "command": "alacritty --title right-panel"},
-            ],
-            "split": "horizontal",
-        }
-    }
-    with pytest.raises(KeyError):
-        layout.Layout(FakeConfig(config), "screen")
 
 
 def test_cant_find_layout():

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -2,6 +2,7 @@ from typing import List, NamedTuple
 
 import pytest
 
+from magic_tiler import interfaces
 from magic_tiler import tiles
 from magic_tiler import windows
 
@@ -15,34 +16,38 @@ class TileTestCase(NamedTuple):
 tile_test_cases: List[TileTestCase] = [
     TileTestCase(
         screen_dimensions=tiles.ScreenDimensions(100, 100),
-        tile_args=[0.2, 0.5, {"command": "echo hi", "id": 1, "name": "hi"}],
+        tile_args=[0.2, 0.5, interfaces.WindowDetails(command="echo hi", mark="hi")],
         expected_tile=tiles.Tile(
             width=20,
             height=50,
-            window=windows.Window(
-                id=1, command="echo hi", width=20, height=50, name="hi"
-            ),
+            window=windows.Window(command="echo hi", width=20, height=50, mark="hi"),
         ),
     ),
     TileTestCase(
         screen_dimensions=tiles.ScreenDimensions(100, 100),
-        tile_args=[0.33, 0.66, {"command": "echo bye", "id": 5, "name": "bye"}],
+        tile_args=[
+            0.33,
+            0.66,
+            interfaces.WindowDetails(command="echo bye", mark="bye"),
+        ],
         expected_tile=tiles.Tile(
             width=33,
             height=66,
-            window=windows.Window(
-                id=5, command="echo bye", width=33, height=66, name="bye"
-            ),
+            window=windows.Window(command="echo bye", width=33, height=66, mark="bye"),
         ),
     ),
     TileTestCase(
         screen_dimensions=tiles.ScreenDimensions(1000, 1000),
-        tile_args=[0.33, 0.554, {"command": "cowsay moo", "id": 5, "name": "moo"}],
+        tile_args=[
+            0.33,
+            0.554,
+            interfaces.WindowDetails(command="cowsay moo", mark="moo"),
+        ],
         expected_tile=tiles.Tile(
             width=330,
             height=554,
             window=windows.Window(
-                id=5, command="cowsay moo", width=330, height=554, name="moo"
+                command="cowsay moo", width=330, height=554, mark="moo"
             ),
         ),
     ),

--- a/tests/test_toml_config.py
+++ b/tests/test_toml_config.py
@@ -11,12 +11,12 @@ def test_toml():
                         {
                             "size": 60,
                             "command": "alacritty --title medium-window",
-                            "name": "medium-window",
+                            "mark": "medium-window",
                         },
                         {
                             "size": 40,
                             "command": "alacritty --title tiny-window",
-                            "name": "tiny-window",
+                            "mark": "tiny-window",
                         },
                     ],
                     "split": "vertical",
@@ -25,12 +25,12 @@ def test_toml():
                 {
                     "size": 50,
                     "command": "alacritty --title middle-panel",
-                    "name": "middle-panel",
+                    "mark": "middle-panel",
                 },
                 {
                     "size": 25,
                     "command": "alacritty --title right-panel",
-                    "name": "right-panel",
+                    "mark": "right-panel",
                 },
             ],
             "split": "horizontal",


### PR DESCRIPTION
Goodbye IDs! You were unnecessarily complicated! Now we use user-defined marks
- Use marks in toml
- Use marks instead of titles to identify windows
- upgrade pytest for verbose testing
- Refactor layout to use marks instead of IDs
