### PR TITLE
Refactor layout

### DIFF
--- a/src/magic_tiler/magic_tiler.py
+++ b/src/magic_tiler/magic_tiler.py
@@ -74,4 +74,5 @@ class MagicTiler(object):
         logging.debug(f"Env is {env}")
 
     def run(self, layout_name: str) -> None:
-        self._layout.spawn_windows(layout_name)
+        self._layout.select(layout_name)
+        self._layout.spawn_windows()

--- a/src/magic_tiler/utils/layouts.py
+++ b/src/magic_tiler/utils/layouts.py
@@ -1,6 +1,6 @@
 import collections
 import logging
-from typing import Dict, List, Set
+from typing import List, Set
 
 from magic_tiler.utils import interfaces
 from magic_tiler.utils import tree
@@ -18,7 +18,7 @@ class Layout(object):
     ) -> None:
         self._window_manager = window_manager
         self._config_reader = config_reader
-        self._root_node: Dict = dict()
+        self._layout_has_been_selected = False
         self._leaf_nodes: List[tree.TreeNode] = []
 
     def select(self, layout_name: str) -> None:
@@ -28,10 +28,11 @@ class Layout(object):
             raise KeyError(f'Could not find layout "{layout_name}" in config')
         if "size" in self._root_node:
             raise RuntimeError("root node shouldn't have a size. size is implied 100")
+        self._layout_has_been_selected = True
         self._root_node["size"] = 100
 
     def spawn_windows(self) -> None:
-        if not self._root_node:
+        if not self._layout_has_been_selected:
             raise RuntimeError("No layout selected")
         logging.debug(
             f"{self._window_manager.num_workspace_windows} windows"

--- a/src/magic_tiler/utils/layouts.py
+++ b/src/magic_tiler/utils/layouts.py
@@ -1,6 +1,6 @@
 import collections
 import logging
-from typing import Set
+from typing import Dict, Set
 
 from magic_tiler.utils import interfaces
 from magic_tiler.utils import tree
@@ -18,6 +18,7 @@ class Layout(object):
     ) -> None:
         self._window_manager = window_manager
         self._config_reader = config_reader
+        self._root_node: Dict = dict()
 
     def select(self, layout_name: str) -> None:
         try:
@@ -29,6 +30,8 @@ class Layout(object):
         self._root_node["size"] = 100
 
     def spawn_windows(self) -> None:
+        if not self._root_node:
+            raise RuntimeError("No layout selected")
         logging.debug(
             f"{self._window_manager.num_workspace_windows} windows"
             + " are open in the current workspace"

--- a/src/magic_tiler/utils/layouts.py
+++ b/src/magic_tiler/utils/layouts.py
@@ -19,7 +19,6 @@ class Layout(object):
         self._window_manager = window_manager
         self._config_reader = config_reader
         self._layout_has_been_selected = False
-        self._leaf_nodes: List[tree.TreeNode] = []
 
     def select(self, layout_name: str) -> None:
         try:
@@ -30,6 +29,7 @@ class Layout(object):
             raise RuntimeError("root node shouldn't have a size. size is implied 100")
         self._layout_has_been_selected = True
         self._root_node["size"] = 100
+        self._leaf_nodes: List[tree.TreeNode] = []
         # TODO: should parse and validate tree here in the future
 
     def spawn_windows(self) -> None:
@@ -47,6 +47,9 @@ class Layout(object):
         self._parse_tree(tree_root)
 
     def _parse_tree(self, root_node: tree.TreeNode) -> None:
+        """Recursively parse the tree, creating, splitting, and focusing windows as
+        appropriate
+        """
         node_queue = collections.deque([root_node])
         self._created_windows: Set[str] = set()
         while len(node_queue) >= 1:

--- a/src/magic_tiler/utils/layouts.py
+++ b/src/magic_tiler/utils/layouts.py
@@ -1,6 +1,6 @@
 import collections
 import logging
-from typing import Dict, Set
+from typing import Dict, List, Set
 
 from magic_tiler.utils import interfaces
 from magic_tiler.utils import tree
@@ -19,6 +19,7 @@ class Layout(object):
         self._window_manager = window_manager
         self._config_reader = config_reader
         self._root_node: Dict = dict()
+        self._leaf_nodes: List[tree.TreeNode] = []
 
     def select(self, layout_name: str) -> None:
         try:
@@ -65,3 +66,4 @@ class Layout(object):
         else:
             self._window_manager.make_window(leftmost_descendant.data)
             self._created_windows.add(leftmost_descendant.data.mark)
+            self._leaf_nodes.append(leftmost_descendant)

--- a/src/magic_tiler/utils/layouts.py
+++ b/src/magic_tiler/utils/layouts.py
@@ -19,7 +19,16 @@ class Layout(object):
         self._window_manager = window_manager
         self._config_reader = config_reader
 
-    def spawn_windows(self, layout_name: str) -> None:
+    def select(self, layout_name: str) -> None:
+        try:
+            self._root_node = self._config_reader.to_dict()[layout_name]
+        except KeyError:
+            raise KeyError(f'Could not find layout "{layout_name}" in config')
+        if "size" in self._root_node:
+            raise RuntimeError("root node shouldn't have a size. size is implied 100")
+        self._root_node["size"] = 100
+
+    def spawn_windows(self) -> None:
         logging.debug(
             f"{self._window_manager.num_workspace_windows} windows"
             + " are open in the current workspace"
@@ -28,14 +37,7 @@ class Layout(object):
             raise RuntimeError(
                 "There are multiple windows open in the current workspace."
             )
-        try:
-            root_node = self._config_reader.to_dict()[layout_name]
-        except KeyError:
-            raise KeyError(f'Could not find layout "{layout_name}" in config')
-        if "size" in root_node:
-            raise RuntimeError("root node shouldn't have a size. size is implied 100")
-        root_node["size"] = 100
-        tree_root = tree.create_tree(root_node)
+        tree_root = tree.create_tree(self._root_node)
         self._parse_tree(tree_root)
 
     def _parse_tree(self, root_node: tree.TreeNode) -> None:

--- a/src/magic_tiler/utils/layouts.py
+++ b/src/magic_tiler/utils/layouts.py
@@ -30,6 +30,7 @@ class Layout(object):
             raise RuntimeError("root node shouldn't have a size. size is implied 100")
         self._layout_has_been_selected = True
         self._root_node["size"] = 100
+        # TODO: should parse and validate tree here in the future
 
     def spawn_windows(self) -> None:
         if not self._layout_has_been_selected:

--- a/tests/test_layouts.py
+++ b/tests/test_layouts.py
@@ -478,3 +478,12 @@ def test_fails_if_too_many_windows_open():
         layout.select("a")
         with pytest.raises(RuntimeError):
             layout.spawn_windows()
+
+
+def test_raises_exception_if_no_selection():
+    layout = layouts.Layout(
+        fakes.FakeConfig({"a": {"split": "laskdjflaskdjf"}}),
+        SpyWindowManager(),
+    )
+    with pytest.raises(RuntimeError):
+        layout.spawn_windows()

--- a/tests/test_layouts.py
+++ b/tests/test_layouts.py
@@ -368,7 +368,8 @@ def test_layout_calls_window_manager(test_case):
     """Make sure we're calling the window manager correctly"""
     spy_window_manager = SpyWindowManager()
     layout = layouts.Layout(fakes.FakeConfig(test_case.config), spy_window_manager)
-    layout.spawn_windows(test_case.layout_name)
+    layout.select(test_case.layout_name)
+    layout.spawn_windows()
     assert spy_window_manager.calls == test_case.expected_call_args
 
 
@@ -378,13 +379,13 @@ def test_cant_find_layout():
         SpyWindowManager(),
     )
     with pytest.raises(KeyError):
-        layout.spawn_windows("a")
+        layout.select("a")
 
 
 def test_size_shouldnt_be_defined_in_root_node():
     layout = layouts.Layout(fakes.FakeConfig({"a": {"size": 9000}}), SpyWindowManager())
     with pytest.raises(RuntimeError):
-        layout.spawn_windows("a")
+        layout.select("a")
 
 
 def test_no_invalid_split_orientation():
@@ -392,8 +393,9 @@ def test_no_invalid_split_orientation():
         fakes.FakeConfig({"a": {"split": "laskdjflaskdjf"}}),
         SpyWindowManager(),
     )
+    layout.select("a")
     with pytest.raises(RuntimeError):
-        layout.spawn_windows("a")
+        layout.spawn_windows()
 
 
 def test_throws_error_if_not_enough_children():
@@ -436,8 +438,9 @@ def test_throws_error_if_not_enough_children():
         )
     )
     for layout in failing_layouts:
+        layout.select("a")
         with pytest.raises(RuntimeError):
-            layout.spawn_windows("a")
+            layout.spawn_windows()
 
     # no exception raised with same config but 2 children
     layout_5 = layouts.Layout(
@@ -462,7 +465,8 @@ def test_throws_error_if_not_enough_children():
         ),
         SpyWindowManager(),
     )
-    layout_5.spawn_windows("a")
+    layout_5.select("a")
+    layout_5.spawn_windows()
 
 
 def test_fails_if_too_many_windows_open():
@@ -471,5 +475,6 @@ def test_fails_if_too_many_windows_open():
             fakes.FakeConfig({"a": {"split": "laskdjflaskdjf"}}),
             SpyWindowManager(num_workspace_windows=i),
         )
+        layout.select("a")
         with pytest.raises(RuntimeError):
-            layout.spawn_windows("a")
+            layout.spawn_windows()

--- a/tests/test_magic_tiler.py
+++ b/tests/test_magic_tiler.py
@@ -111,4 +111,5 @@ def test_run():
     layout = mock.MagicMock()
     application = magic_tiler.MagicTiler(env, layout, 0)
     application.run("my_ide")
-    layout.spawn_windows.assert_called_once_with("my_ide")
+    layout.select.assert_called_once_with("my_ide")
+    layout.spawn_windows.assert_called_once_with()


### PR DESCRIPTION
Getting Layout ready for some window-resizing action!

We separate the selection and spawning commands so that we can make room for a resizing command. That way we can select and resize if we want to and skip the spawning action. This will make it easier to test and also easier to debug since we can pause the process and see the spawned windows before we resize them. 
- Add a selection command to Layout
- Check to make sure there's a layout selected
- Track leaf nodes in layout
- Use boolean instead of empty dict
- Add comment
- Move code and add docstring
