### PR TITLE
Separate Layout Parsing from Window Management

### DIFF
--- a/src/magic_tiler/magic_tiler.py
+++ b/src/magic_tiler/magic_tiler.py
@@ -53,7 +53,7 @@ def main(
     env = dtos.Env(home=user_home_dir, xdg_config_home=xdg_config_home_dir)
     config = configs.TomlConfig(filestore.LocalFilestore(), env=env)
     window_manager = sway.Sway()
-    layout = layouts.Layout(config, window_manager)
+    layout = layouts.LayoutManager(config, window_manager)
     application = MagicTiler(env, layout, verbosity_level)
     application.run(layout_name)
 
@@ -64,7 +64,7 @@ class MagicTiler(object):
     def __init__(
         self,
         env: dtos.Env,
-        layout: layouts.Layout,
+        layout: layouts.LayoutManager,
         verbosity_level: int,
     ) -> None:
         self._layout = layout

--- a/src/magic_tiler/utils/dtos.py
+++ b/src/magic_tiler/utils/dtos.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 # data-transfer objects (DTOs)
 # objects that don't have much functionality besides storing
@@ -41,3 +41,10 @@ class Env(NamedTuple):
 
     home: str
     xdg_config_home: str
+
+
+class WindowManagerCall(NamedTuple):
+    """Used for verifying calls to a window manager"""
+
+    command: str
+    arg: Any

--- a/src/magic_tiler/utils/layouts.py
+++ b/src/magic_tiler/utils/layouts.py
@@ -30,7 +30,6 @@ class LayoutManager(object):
         self._layout_has_been_selected = True
         self._selected_layout = Layout(self._root_node)
         self._root_node["size"] = 100
-        # TODO: should parse and validate tree here in the future
 
     def spawn_windows(self) -> None:
         if not self._layout_has_been_selected:

--- a/src/magic_tiler/utils/layouts.py
+++ b/src/magic_tiler/utils/layouts.py
@@ -1,6 +1,6 @@
 import collections
 import logging
-from typing import Dict, Set
+from typing import Dict, Iterable, Set
 
 from magic_tiler.utils import interfaces
 from magic_tiler.utils import tree
@@ -28,7 +28,7 @@ class LayoutManager(object):
         if "size" in self._root_node:
             raise RuntimeError("root node shouldn't have a size. size is implied 100")
         self._layout_has_been_selected = True
-        self._selected_layout = Layout(self._window_manager, self._root_node)
+        self._selected_layout = Layout(self._root_node)
         self._root_node["size"] = 100
         # TODO: should parse and validate tree here in the future
 
@@ -43,42 +43,30 @@ class LayoutManager(object):
             raise RuntimeError(
                 "There are multiple windows open in the current workspace."
             )
-        self._selected_layout.spawn_windows()
+        self._created_windows: Set[str] = set()
+        for window in self._selected_layout.zachstras_traversal():
+            if window.is_parent:
+                self._window_manager.split(window.data)
+            elif window.data.mark in self._created_windows:
+                self._window_manager.focus(window.data)
+            else:
+                self._window_manager.make_window(window.data)
+                self._created_windows.add(window.data.mark)
 
 
 class Layout(object):
-    # todo: extract window manager from layout's responsibilities
-    def __init__(
-        self, window_manager: interfaces.TilingWindowManager, root_node: Dict
-    ) -> None:
+    def __init__(self, root_node: Dict) -> None:
         self._tree = tree.create_tree(root_node)
-        self._window_manager = window_manager
 
-    def spawn_windows(self) -> None:
-        self._parse_tree(self._tree)
-
-    def _parse_tree(self, root_node: tree.TreeNode) -> None:
-        """Recursively parse the tree, creating, splitting, and focusing windows as
-        appropriate
-        """
-        node_queue = collections.deque([root_node])
-        self._created_windows: Set[str] = set()
+    def zachstras_traversal(self) -> Iterable[tree.TreeNode]:
+        node_queue = collections.deque([self._tree])
         while len(node_queue) >= 1:
             current_node = node_queue.popleft()
             logging.debug(f"dequeuing {current_node}")
             if current_node.is_parent:
-                self._attempt_to_create_leftmost_descendant(current_node.children[0])
-                self._window_manager.split(current_node.data)
+                yield current_node.children[0].get_leftmost_descendant()
+                yield current_node
                 for child in current_node.children[1:]:
-                    self._attempt_to_create_leftmost_descendant(child)
+                    yield child.get_leftmost_descendant()
                 for child in current_node.children:
                     node_queue.append(child)
-
-    def _attempt_to_create_leftmost_descendant(self, node: tree.TreeNode) -> None:
-        logging.debug(f"getting leftmost descendant of {node}")
-        leftmost_descendant = node.get_leftmost_descendant()
-        if leftmost_descendant.data.mark in self._created_windows:
-            self._window_manager.focus(leftmost_descendant.data)
-        else:
-            self._window_manager.make_window(leftmost_descendant.data)
-            self._created_windows.add(leftmost_descendant.data.mark)

--- a/src/magic_tiler/utils/layouts.py
+++ b/src/magic_tiler/utils/layouts.py
@@ -10,7 +10,7 @@ from magic_tiler.utils import tree
 # space for its other siblings.
 
 
-class Layout(object):
+class LayoutManager(object):
     def __init__(
         self,
         config_reader: interfaces.ConfigReader,

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -97,15 +97,14 @@ class FakeWindowManager(interfaces.TilingWindowManager):
         return self._window_sizes
 
 
-class SpyWindowManager(interfaces.TilingWindowManager):
-    """Gets passed into LayoutManagers using dependency injection
-    and spies on their calls so we can make sure that we're handling
-    window creation correctly
+class SpyWindowManager(FakeWindowManager):
+    """Gets passed into LayoutManagers using dependency injection and spies on their
+    calls so we can make sure that we're making the right window commands
     """
 
-    def __init__(self, num_workspace_windows: int = 0):
+    def __init__(self, **kwargs):
         self._calls: List[dtos.WindowManagerCall] = []
-        self._num_workspace_windows = num_workspace_windows
+        super().__init__(**kwargs)
 
     def make_window(
         self,
@@ -116,10 +115,6 @@ class SpyWindowManager(interfaces.TilingWindowManager):
     @property
     def calls(self):
         return self._calls
-
-    @property
-    def num_workspace_windows(self):
-        return self._num_workspace_windows
 
     def resize_width(
         self, target_window: dtos.WindowDetails, container_percentage: int
@@ -136,9 +131,3 @@ class SpyWindowManager(interfaces.TilingWindowManager):
 
     def split(self, split_type: str) -> None:
         self._calls.append(dtos.WindowManagerCall("split", arg=split_type))
-
-    def get_tree(self):
-        pass
-
-    def get_window_sizes(self) -> Dict:
-        pass

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -106,15 +106,15 @@ class SpyWindowManager(FakeWindowManager):
         self._calls: List[dtos.WindowManagerCall] = []
         super().__init__(**kwargs)
 
+    @property
+    def calls(self):
+        return self._calls
+
     def make_window(
         self,
         window_details: dtos.WindowDetails,
     ) -> None:
         self._calls.append(dtos.WindowManagerCall(command="make", arg=window_details))
-
-    @property
-    def calls(self):
-        return self._calls
 
     def resize_width(
         self, target_window: dtos.WindowDetails, container_percentage: int

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -95,3 +95,50 @@ class FakeWindowManager(interfaces.TilingWindowManager):
 
     def get_window_sizes(self):
         return self._window_sizes
+
+
+class SpyWindowManager(interfaces.TilingWindowManager):
+    """Gets passed into LayoutManagers using dependency injection
+    and spies on their calls so we can make sure that we're handling
+    window creation correctly
+    """
+
+    def __init__(self, num_workspace_windows: int = 0):
+        self._calls: List[dtos.WindowManagerCall] = []
+        self._num_workspace_windows = num_workspace_windows
+
+    def make_window(
+        self,
+        window_details: dtos.WindowDetails,
+    ) -> None:
+        self._calls.append(dtos.WindowManagerCall(command="make", arg=window_details))
+
+    @property
+    def calls(self):
+        return self._calls
+
+    @property
+    def num_workspace_windows(self):
+        return self._num_workspace_windows
+
+    def resize_width(
+        self, target_window: dtos.WindowDetails, container_percentage: int
+    ) -> None:
+        pass
+
+    def resize_height(
+        self, target_window: dtos.WindowDetails, container_percentage: int
+    ) -> None:
+        pass
+
+    def focus(self, target_window: dtos.WindowDetails) -> None:
+        self._calls.append(dtos.WindowManagerCall("focus", arg=target_window))
+
+    def split(self, split_type: str) -> None:
+        self._calls.append(dtos.WindowManagerCall("split", arg=split_type))
+
+    def get_tree(self):
+        pass
+
+    def get_window_sizes(self) -> Dict:
+        pass

--- a/tests/test_layouts.py
+++ b/tests/test_layouts.py
@@ -392,14 +392,13 @@ def test_size_shouldnt_be_defined_in_root_node():
         layout.select("a")
 
 
-def test_no_invalid_split_orientation():
+def test_fails_if_invalid_split_orientation():
     layout = layouts.LayoutManager(
         fakes.FakeConfig({"a": {"split": "laskdjflaskdjf"}}),
         SpyWindowManager(),
     )
-    layout.select("a")
     with pytest.raises(RuntimeError):
-        layout.spawn_windows()
+        layout.select("a")
 
 
 def test_throws_error_if_not_enough_children():
@@ -442,9 +441,8 @@ def test_throws_error_if_not_enough_children():
         )
     )
     for layout in failing_layouts:
-        layout.select("a")
         with pytest.raises(RuntimeError):
-            layout.spawn_windows()
+            layout.select("a")
 
     # no exception raised with same config but 2 children
     layout_5 = layouts.LayoutManager(
@@ -476,10 +474,17 @@ def test_throws_error_if_not_enough_children():
 def test_fails_if_too_many_windows_open():
     for i in [2, 20, 100]:
         layout = layouts.LayoutManager(
-            fakes.FakeConfig({"a": {"split": "laskdjflaskdjf"}}),
+            fakes.FakeConfig(
+                {
+                    "screen": {
+                        "mark": "mymark",
+                        "command": "alacritty",
+                    },
+                }
+            ),
             SpyWindowManager(num_workspace_windows=i),
         )
-        layout.select("a")
+        layout.select("screen")
         with pytest.raises(RuntimeError):
             layout.spawn_windows()
 

--- a/tests/test_layouts.py
+++ b/tests/test_layouts.py
@@ -15,7 +15,7 @@ class WindowManagerCall(NamedTuple):
 
 class SpyWindowManager(interfaces.TilingWindowManager):
     """Gets passed into LayoutManagers using dependency injection
-    and spys on their calls so we can make sure that we're handling
+    and spies on their calls so we can make sure that we're handling
     window creation correctly
     """
 

--- a/tests/test_layouts.py
+++ b/tests/test_layouts.py
@@ -325,7 +325,7 @@ def test_layout_calls_window_manager(test_case):
 def test_cant_find_layout():
     layout = layouts.LayoutManager(
         fakes.FakeConfig(layout_test_cases[0].config),
-        fakes.SpyWindowManager(),
+        fakes.FakeWindowManager(),
     )
     with pytest.raises(KeyError):
         layout.select("doesn't exist abcdefg")
@@ -333,7 +333,7 @@ def test_cant_find_layout():
 
 def test_size_shouldnt_be_defined_in_root_node():
     layout = layouts.LayoutManager(
-        fakes.FakeConfig({"a": {"size": 9000}}), fakes.SpyWindowManager()
+        fakes.FakeConfig({"a": {"size": 9000}}), fakes.FakeWindowManager()
     )
     with pytest.raises(RuntimeError):
         layout.select("a")
@@ -342,7 +342,7 @@ def test_size_shouldnt_be_defined_in_root_node():
 def test_fails_if_invalid_split_orientation():
     layout = layouts.LayoutManager(
         fakes.FakeConfig({"a": {"split": "laskdjflaskdjf"}}),
-        fakes.SpyWindowManager(),
+        fakes.FakeWindowManager(),
     )
     with pytest.raises(RuntimeError):
         layout.select("a")
@@ -366,7 +366,7 @@ def test_throws_error_if_not_enough_children(num_children):
                 }
             }
         ),
-        fakes.SpyWindowManager(),
+        fakes.FakeWindowManager(),
     )
     with pytest.raises(RuntimeError):
         layout_manager.select("a")
@@ -391,7 +391,7 @@ def test_doesnt_raise_exception_when_2_or_more_children(num_children):
                 }
             }
         ),
-        fakes.SpyWindowManager(),
+        fakes.FakeWindowManager(),
     )
     layout_manager.select("a")
     layout_manager.spawn_windows()
@@ -408,7 +408,7 @@ def test_fails_if_too_many_windows_open(num_open_windows):
                 },
             }
         ),
-        fakes.SpyWindowManager(num_workspace_windows=num_open_windows),
+        fakes.FakeWindowManager(num_workspace_windows=num_open_windows),
     )
     layout.select("screen")
     with pytest.raises(RuntimeError):
@@ -418,7 +418,7 @@ def test_fails_if_too_many_windows_open(num_open_windows):
 def test_raises_exception_if_no_selection():
     layout = layouts.LayoutManager(
         fakes.FakeConfig({}),
-        fakes.SpyWindowManager(),
+        fakes.FakeWindowManager(),
     )
     with pytest.raises(RuntimeError):
         layout.spawn_windows()

--- a/tests/test_layouts.py
+++ b/tests/test_layouts.py
@@ -402,26 +402,26 @@ def test_fails_if_invalid_split_orientation():
 
 
 def test_throws_error_if_not_enough_children():
-    failing_layouts = []
-    failing_layouts.append(
+    failing_layout_managers = []
+    failing_layout_managers.append(
         layouts.LayoutManager(
             fakes.FakeConfig({"a": {"split": "horizontal", "children": []}}),
             SpyWindowManager(),
         )
     )
-    failing_layouts.append(
+    failing_layout_managers.append(
         layouts.LayoutManager(
             fakes.FakeConfig({"a": {"split": "horizontal", "children": []}}),
             SpyWindowManager(),
         )
     )
-    failing_layouts.append(
+    failing_layout_managers.append(
         layouts.LayoutManager(
             fakes.FakeConfig({"a": {"split": "horizontal", "children": []}}),
             SpyWindowManager(),
         )
     )
-    failing_layouts.append(
+    failing_layout_managers.append(
         layouts.LayoutManager(
             fakes.FakeConfig(
                 {
@@ -440,12 +440,12 @@ def test_throws_error_if_not_enough_children():
             SpyWindowManager(),
         )
     )
-    for layout in failing_layouts:
+    for layout in failing_layout_managers:
         with pytest.raises(RuntimeError):
             layout.select("a")
 
     # no exception raised with same config but 2 children
-    layout_5 = layouts.LayoutManager(
+    successful_layout_manager = layouts.LayoutManager(
         fakes.FakeConfig(
             {
                 "a": {
@@ -467,8 +467,8 @@ def test_throws_error_if_not_enough_children():
         ),
         SpyWindowManager(),
     )
-    layout_5.select("a")
-    layout_5.spawn_windows()
+    successful_layout_manager.select("a")
+    successful_layout_manager.spawn_windows()
 
 
 def test_fails_if_too_many_windows_open():

--- a/tests/test_layouts.py
+++ b/tests/test_layouts.py
@@ -1,68 +1,15 @@
-from typing import Any, Dict, List, NamedTuple
+from typing import Dict, List, NamedTuple
 
 import pytest
 
 from magic_tiler.utils import dtos
-from magic_tiler.utils import interfaces
 from magic_tiler.utils import layouts
 from tests import fakes
 
 
-class WindowManagerCall(NamedTuple):
-    command: str
-    arg: Any
-
-
-class SpyWindowManager(interfaces.TilingWindowManager):
-    """Gets passed into LayoutManagers using dependency injection
-    and spies on their calls so we can make sure that we're handling
-    window creation correctly
-    """
-
-    def __init__(self, num_workspace_windows: int = 0):
-        self._calls: List[WindowManagerCall] = []
-        self._num_workspace_windows = num_workspace_windows
-
-    def make_window(
-        self,
-        window_details: dtos.WindowDetails,
-    ) -> None:
-        self._calls.append(WindowManagerCall(command="make", arg=window_details))
-
-    @property
-    def calls(self):
-        return self._calls
-
-    @property
-    def num_workspace_windows(self):
-        return self._num_workspace_windows
-
-    def resize_width(
-        self, target_window: dtos.WindowDetails, container_percentage: int
-    ) -> None:
-        pass
-
-    def resize_height(
-        self, target_window: dtos.WindowDetails, container_percentage: int
-    ) -> None:
-        pass
-
-    def focus(self, target_window: dtos.WindowDetails) -> None:
-        self._calls.append(WindowManagerCall("focus", arg=target_window))
-
-    def split(self, split_type: str) -> None:
-        self._calls.append(WindowManagerCall("split", arg=split_type))
-
-    def get_tree(self):
-        pass
-
-    def get_window_sizes(self) -> Dict:
-        pass
-
-
 class LayoutManagerTestCase(NamedTuple):
     config: Dict
-    expected_call_args: List[WindowManagerCall]
+    expected_call_args: List[dtos.WindowManagerCall]
     layout_name: str
 
 
@@ -102,24 +49,24 @@ layout_test_cases = [
             }
         },
         expected_call_args=[
-            WindowManagerCall(
+            dtos.WindowManagerCall(
                 command="make",
                 arg=dtos.WindowDetails(mark="medium", command="alacritty"),
             ),
-            WindowManagerCall(command="split", arg="horizontal"),
-            WindowManagerCall(
+            dtos.WindowManagerCall(command="split", arg="horizontal"),
+            dtos.WindowManagerCall(
                 command="make", arg=dtos.WindowDetails(mark="big", command="alacritty")
             ),
-            WindowManagerCall(
+            dtos.WindowManagerCall(
                 command="make",
                 arg=dtos.WindowDetails(mark="right", command="alacritty"),
             ),
-            WindowManagerCall(
+            dtos.WindowManagerCall(
                 command="focus",
                 arg=dtos.WindowDetails(mark="medium", command="alacritty"),
             ),
-            WindowManagerCall(command="split", arg="vertical"),
-            WindowManagerCall(
+            dtos.WindowManagerCall(command="split", arg="vertical"),
+            dtos.WindowManagerCall(
                 command="make",
                 arg=dtos.WindowDetails(mark="small", command="alacritty"),
             ),
@@ -150,15 +97,15 @@ layout_test_cases = [
             }
         },
         expected_call_args=[
-            WindowManagerCall(
+            dtos.WindowManagerCall(
                 command="make", arg=dtos.WindowDetails(mark="left", command="alacritty")
             ),
-            WindowManagerCall(command="split", arg="horizontal"),
-            WindowManagerCall(
+            dtos.WindowManagerCall(command="split", arg="horizontal"),
+            dtos.WindowManagerCall(
                 command="make",
                 arg=dtos.WindowDetails(mark="center", command="alacritty"),
             ),
-            WindowManagerCall(
+            dtos.WindowManagerCall(
                 command="make",
                 arg=dtos.WindowDetails(mark="right", command="alacritty"),
             ),
@@ -206,21 +153,21 @@ layout_test_cases = [
             },
         },
         expected_call_args=[
-            WindowManagerCall(
+            dtos.WindowManagerCall(
                 command="make",
                 arg=dtos.WindowDetails(mark="linter", command="alacritty"),
             ),
-            WindowManagerCall(command="split", arg="horizontal"),
-            WindowManagerCall(
+            dtos.WindowManagerCall(command="split", arg="horizontal"),
+            dtos.WindowManagerCall(
                 command="make",
                 arg=dtos.WindowDetails(mark="jumbo", command="alacritty"),
             ),
-            WindowManagerCall(
+            dtos.WindowManagerCall(
                 command="focus",
                 arg=dtos.WindowDetails(mark="linter", command="alacritty"),
             ),
-            WindowManagerCall(command="split", arg="vertical"),
-            WindowManagerCall(
+            dtos.WindowManagerCall(command="split", arg="vertical"),
+            dtos.WindowManagerCall(
                 command="make",
                 arg=dtos.WindowDetails(mark="terminal", command="alacritty"),
             ),
@@ -299,62 +246,62 @@ layout_test_cases = [
             }
         },
         expected_call_args=[
-            WindowManagerCall(
+            dtos.WindowManagerCall(
                 command="make", arg=dtos.WindowDetails(mark="A", command="alacritty")
             ),
-            WindowManagerCall(command="split", arg="horizontal"),
-            WindowManagerCall(
+            dtos.WindowManagerCall(command="split", arg="horizontal"),
+            dtos.WindowManagerCall(
                 command="make", arg=dtos.WindowDetails(mark="C", command="alacritty")
             ),
-            WindowManagerCall(
+            dtos.WindowManagerCall(
                 command="focus",
                 arg=dtos.WindowDetails(mark="A", command="alacritty"),
             ),
-            WindowManagerCall(command="split", arg="vertical"),
-            WindowManagerCall(
+            dtos.WindowManagerCall(command="split", arg="vertical"),
+            dtos.WindowManagerCall(
                 command="make", arg=dtos.WindowDetails(mark="F", command="alacritty")
             ),
-            WindowManagerCall(
+            dtos.WindowManagerCall(
                 command="make", arg=dtos.WindowDetails(mark="I", command="alacritty")
             ),
-            WindowManagerCall(
+            dtos.WindowManagerCall(
                 command="focus",
                 arg=dtos.WindowDetails(mark="C", command="alacritty"),
             ),
-            WindowManagerCall(command="split", arg="vertical"),
-            WindowManagerCall(
+            dtos.WindowManagerCall(command="split", arg="vertical"),
+            dtos.WindowManagerCall(
                 command="make", arg=dtos.WindowDetails(mark="H", command="alacritty")
             ),
-            WindowManagerCall(
+            dtos.WindowManagerCall(
                 command="focus",
                 arg=dtos.WindowDetails(mark="A", command="alacritty"),
             ),
-            WindowManagerCall(command="split", arg="horizontal"),
-            WindowManagerCall(
+            dtos.WindowManagerCall(command="split", arg="horizontal"),
+            dtos.WindowManagerCall(
                 command="make", arg=dtos.WindowDetails(mark="B", command="alacritty")
             ),
-            WindowManagerCall(
+            dtos.WindowManagerCall(
                 command="focus",
                 arg=dtos.WindowDetails(mark="F", command="alacritty"),
             ),
-            WindowManagerCall(command="split", arg="horizontal"),
-            WindowManagerCall(
+            dtos.WindowManagerCall(command="split", arg="horizontal"),
+            dtos.WindowManagerCall(
                 command="make", arg=dtos.WindowDetails(mark="G", command="alacritty")
             ),
-            WindowManagerCall(
+            dtos.WindowManagerCall(
                 command="focus",
                 arg=dtos.WindowDetails(mark="C", command="alacritty"),
             ),
-            WindowManagerCall(command="split", arg="horizontal"),
-            WindowManagerCall(
+            dtos.WindowManagerCall(command="split", arg="horizontal"),
+            dtos.WindowManagerCall(
                 command="make", arg=dtos.WindowDetails(mark="D", command="alacritty")
             ),
-            WindowManagerCall(
+            dtos.WindowManagerCall(
                 command="focus",
                 arg=dtos.WindowDetails(mark="D", command="alacritty"),
             ),
-            WindowManagerCall(command="split", arg="vertical"),
-            WindowManagerCall(
+            dtos.WindowManagerCall(command="split", arg="vertical"),
+            dtos.WindowManagerCall(
                 command="make", arg=dtos.WindowDetails(mark="E", command="alacritty")
             ),
         ],
@@ -366,7 +313,7 @@ layout_test_cases = [
 @pytest.mark.parametrize("test_case", layout_test_cases)
 def test_layout_calls_window_manager(test_case):
     """Make sure we're calling the window manager correctly"""
-    spy_window_manager = SpyWindowManager()
+    spy_window_manager = fakes.SpyWindowManager()
     layout = layouts.LayoutManager(
         fakes.FakeConfig(test_case.config), spy_window_manager
     )
@@ -378,7 +325,7 @@ def test_layout_calls_window_manager(test_case):
 def test_cant_find_layout():
     layout = layouts.LayoutManager(
         fakes.FakeConfig(layout_test_cases[0].config),
-        SpyWindowManager(),
+        fakes.SpyWindowManager(),
     )
     with pytest.raises(KeyError):
         layout.select("doesn't exist abcdefg")
@@ -386,7 +333,7 @@ def test_cant_find_layout():
 
 def test_size_shouldnt_be_defined_in_root_node():
     layout = layouts.LayoutManager(
-        fakes.FakeConfig({"a": {"size": 9000}}), SpyWindowManager()
+        fakes.FakeConfig({"a": {"size": 9000}}), fakes.SpyWindowManager()
     )
     with pytest.raises(RuntimeError):
         layout.select("a")
@@ -395,7 +342,7 @@ def test_size_shouldnt_be_defined_in_root_node():
 def test_fails_if_invalid_split_orientation():
     layout = layouts.LayoutManager(
         fakes.FakeConfig({"a": {"split": "laskdjflaskdjf"}}),
-        SpyWindowManager(),
+        fakes.SpyWindowManager(),
     )
     with pytest.raises(RuntimeError):
         layout.select("a")
@@ -419,7 +366,7 @@ def test_throws_error_if_not_enough_children(num_children):
                 }
             }
         ),
-        SpyWindowManager(),
+        fakes.SpyWindowManager(),
     )
     with pytest.raises(RuntimeError):
         layout_manager.select("a")
@@ -444,7 +391,7 @@ def test_doesnt_raise_exception_when_2_or_more_children(num_children):
                 }
             }
         ),
-        SpyWindowManager(),
+        fakes.SpyWindowManager(),
     )
     layout_manager.select("a")
     layout_manager.spawn_windows()
@@ -461,7 +408,7 @@ def test_fails_if_too_many_windows_open(num_open_windows):
                 },
             }
         ),
-        SpyWindowManager(num_workspace_windows=num_open_windows),
+        fakes.SpyWindowManager(num_workspace_windows=num_open_windows),
     )
     layout.select("screen")
     with pytest.raises(RuntimeError):
@@ -471,7 +418,7 @@ def test_fails_if_too_many_windows_open(num_open_windows):
 def test_raises_exception_if_no_selection():
     layout = layouts.LayoutManager(
         fakes.FakeConfig({}),
-        SpyWindowManager(),
+        fakes.SpyWindowManager(),
     )
     with pytest.raises(RuntimeError):
         layout.spawn_windows()

--- a/tests/test_layouts.py
+++ b/tests/test_layouts.py
@@ -381,7 +381,7 @@ def test_cant_find_layout():
         SpyWindowManager(),
     )
     with pytest.raises(KeyError):
-        layout.select("a")
+        layout.select("doesn't exist abcdefg")
 
 
 def test_size_shouldnt_be_defined_in_root_node():

--- a/tests/test_magic_tiler.py
+++ b/tests/test_magic_tiler.py
@@ -23,8 +23,8 @@ def MockConfig(mocker):
 
 
 @pytest.fixture
-def MockLayout(mocker):
-    return mocker.patch("magic_tiler.utils.layouts.Layout")
+def MockLayoutManager(mocker):
+    return mocker.patch("magic_tiler.utils.layouts.LayoutManager")
 
 
 # how do we even run an end-to-end test?? a sandboxed vm that runs a window manager?
@@ -89,7 +89,7 @@ def test_successful_script(
     MockWindowManager,
     MockMagicTiler,
     MockConfig,
-    MockLayout,
+    MockLayoutManager,
     test_parameters,
 ):
     """Verify that we're setting up dependencies and calling MagicTiler correctly"""
@@ -100,7 +100,7 @@ def test_successful_script(
     assert "" == result.output, result.exception
     MockMagicTiler.assert_called_once_with(
         test_parameters.expected_parsed_env,
-        MockLayout(),
+        MockLayoutManager(),
         test_parameters.expected_verbosity,
     )
     MockMagicTiler.return_value.run.assert_called_once_with(test_parameters.cli_args[0])


### PR DESCRIPTION
By separating layout parsing from window management, we can prepare for window resizing and keep it separate from window spawning. It'll be easier to test and more decoupled