### PR TITLE
Mark containers when splitting them

### DIFF
--- a/src/magic_tiler/utils/config_parser.py
+++ b/src/magic_tiler/utils/config_parser.py
@@ -60,17 +60,20 @@ class ConfigParser(interfaces.ConfigParserInterface):
         create a tree out of them.
         """
         layout_top_definition = self._layout_definitions[layout_name]
+        layout_top_definition["mark"] = layout_name
         root_node = self._construct_subtree(layout_top_definition)
         return self._tree_factory.create_tree(root_node)
 
     def _construct_subtree(self, subtree_dict: Dict) -> Dict:
-        if "mark" in subtree_dict:
+        if "command" in subtree_dict:
             return subtree_dict.copy()
         else:
             subtree = subtree_dict.copy()
             child_subtrees = []
             for child in subtree["children"]:
                 child_definition = self._layout_definitions[child]
+                if "mark" not in child_definition:
+                    child_definition["mark"] = child
                 child_subtrees.append(self._construct_subtree(child_definition))
             subtree["children"] = child_subtrees
             return subtree

--- a/src/magic_tiler/utils/interfaces.py
+++ b/src/magic_tiler/utils/interfaces.py
@@ -29,7 +29,7 @@ class TilingWindowManager(object):
         pass
 
     @abc.abstractmethod
-    def split(self, split_type: str) -> None:
+    def split_and_mark_parent(self, split_type: str, mark: str) -> None:
         pass
 
     @property

--- a/src/magic_tiler/utils/layouts.py
+++ b/src/magic_tiler/utils/layouts.py
@@ -40,7 +40,7 @@ class LayoutManager(object):
         self._created_windows: Set[str] = set()
         for window in self._selected_layout.zachstras_traversal():
             if window.is_parent:
-                self._window_manager.split(window.data)
+                self._window_manager.split_and_mark_parent(window.data, "abc")
             elif window.data.mark in self._created_windows:
                 self._window_manager.focus(window.data)
             else:

--- a/src/magic_tiler/utils/sway.py
+++ b/src/magic_tiler/utils/sway.py
@@ -45,7 +45,7 @@ class Sway(interfaces.TilingWindowManager):
         focused.command("focus parent")
         time.sleep(SLEEP_TIME)
         parent = self._get_focused_window()
-        parent.command("mark {window_details.mark}")
+        parent.command(f"mark {mark}")
         time.sleep(SLEEP_TIME)
         # need to give focus back to the window that we just focused
         focused.command("focus")

--- a/src/magic_tiler/utils/sway.py
+++ b/src/magic_tiler/utils/sway.py
@@ -30,7 +30,7 @@ class Sway(interfaces.TilingWindowManager):
         window.command("focus")
         return window
 
-    def split(self, split_type: str) -> None:
+    def split_and_mark_parent(self, split_type: str, mark: str) -> None:
         focused = self._get_focused_window()
         if split_type == "vertical":
             focused.command("split vertical")
@@ -38,6 +38,9 @@ class Sway(interfaces.TilingWindowManager):
             focused.command("split horizontal")
         else:
             raise RuntimeError(f"invalid split type: {split_type}")
+        focused.command("focus parent")
+        parent = self._get_focused_window()
+        parent.command("mark {window_details.mark}")
 
     def resize_width(
         self, target_window: dtos.WindowDetails, container_percentage: int

--- a/src/magic_tiler/utils/sway.py
+++ b/src/magic_tiler/utils/sway.py
@@ -26,6 +26,7 @@ class Sway(interfaces.TilingWindowManager):
         self._sway.command(f"exec {window_details.command}")
         time.sleep(SLEEP_TIME)
         self._get_focused_window().command(f"mark {window_details.mark}")
+        time.sleep(SLEEP_TIME)
 
     def focus(self, target_window: dtos.WindowDetails) -> i3ipc.Con:
         window = self._get_window(target_window.mark)
@@ -40,11 +41,15 @@ class Sway(interfaces.TilingWindowManager):
             focused.command("split horizontal")
         else:
             raise RuntimeError(f"invalid split type: {split_type}")
+        time.sleep(SLEEP_TIME)
         focused.command("focus parent")
+        time.sleep(SLEEP_TIME)
         parent = self._get_focused_window()
         parent.command("mark {window_details.mark}")
+        time.sleep(SLEEP_TIME)
         # need to give focus back to the window that we just focused
         focused.command("focus")
+        time.sleep(SLEEP_TIME)
 
     def resize_width(
         self, target_window: dtos.WindowDetails, container_percentage: int

--- a/src/magic_tiler/utils/sway.py
+++ b/src/magic_tiler/utils/sway.py
@@ -14,6 +14,8 @@ split.
 """
 SLEEP_TIME = 0.30
 
+# TODO: add logging for commands
+
 
 class Sway(interfaces.TilingWindowManager):
     def __init__(self) -> None:

--- a/src/magic_tiler/utils/sway.py
+++ b/src/magic_tiler/utils/sway.py
@@ -43,6 +43,8 @@ class Sway(interfaces.TilingWindowManager):
         focused.command("focus parent")
         parent = self._get_focused_window()
         parent.command("mark {window_details.mark}")
+        # need to give focus back to the window that we just focused
+        focused.command("focus")
 
     def resize_width(
         self, target_window: dtos.WindowDetails, container_percentage: int

--- a/src/magic_tiler/utils/tree.py
+++ b/src/magic_tiler/utils/tree.py
@@ -17,7 +17,7 @@ class TreeFactory(interfaces.TreeFactoryInterface):
     ) -> TreeNode:
         """Recursively create the subtree of the current node and everything below it"""
         current_node: TreeNode
-        if "mark" in node:
+        if "command" in node:
             current_node = Window(
                 dtos.WindowDetails(mark=node["mark"], command=node["command"]),
                 parent=parent,
@@ -27,7 +27,7 @@ class TreeFactory(interfaces.TreeFactoryInterface):
             if len(node["children"]) <= 1:
                 raise RuntimeError("each parent needs at least 2 children")
             for child in node["children"]:
-                self._create_subtree(child, current_node)
+                self._create_subtree(child, parent=current_node)
         else:
             logging.error(node)
             raise RuntimeError("invalid config file")

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -98,7 +98,7 @@ class FakeWindowManager(interfaces.TilingWindowManager):
     def focus(self, target_window: dtos.WindowDetails) -> None:
         pass
 
-    def split(self, split_type: str) -> None:
+    def split_and_mark_parent(self, split_type: str, mark: str) -> None:
         pass
 
     @property
@@ -145,5 +145,6 @@ class SpyWindowManager(FakeWindowManager):
     def focus(self, target_window: dtos.WindowDetails) -> None:
         self._calls.append(dtos.WindowManagerCall("focus", arg=target_window))
 
-    def split(self, split_type: str) -> None:
+    # todo: add the mark to the call
+    def split_and_mark_parent(self, split_type: str, mark: str) -> None:
         self._calls.append(dtos.WindowManagerCall("split", arg=split_type))

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -58,6 +58,7 @@ test_cases = [
         expected_tree={
             "split": "horizontal",
             "sizes": [50, 50],
+            "mark": "ide",
             "children": [
                 {
                     "command": 'alacritty -e sh -c "echo left window!"',
@@ -99,10 +100,12 @@ test_cases = [
         expected_tree={
             "split": "horizontal",
             "sizes": [50, 50],
+            "mark": "3 windows",
             "children": [
                 {
                     "split": "vertical",
                     "sizes": [40, 60],
+                    "mark": "left side",
                     "children": [
                         {
                             "command": 'alacritty -e sh -c "echo I\'m in the top left!"',


### PR DESCRIPTION
- Change the Sway command to split and mark
- Add todo
- Minor refactors
- Fix bug where windows weren't being spawned correctly
- Add extra sleep times to window manager
- Add container marks to config parser
- Fix mark command
