### PR TITLE
print layout names

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -3,6 +3,7 @@
 [mypy]
 check_untyped_defs = True
 pretty = True
+show_error_codes = True
 
 [mypy-i3ipc,pytest]
 ignore_missing_imports = True

--- a/src/magic_tiler/magic_tiler.py
+++ b/src/magic_tiler/magic_tiler.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-from typing import Any
+from typing import Any, Dict
 
 import click
 
@@ -25,16 +25,7 @@ VERBOSITY_LOG_LEVELS = {
 # open windows or run commands? maybe a fake supbrocess runner?
 
 
-# these types can be Any because this function declaration was lifted from the docs
-def list_layouts(context: Any, param: Any, value: Any) -> None:
-    """Callback function which lists all available layouts"""
-    if not value or context.resilient_parsing:
-        return
-    click.echo("these are your layouts")
-    context.exit()
-
-
-@click.command()
+@click.group()
 @click.option(
     "-v",
     "--verbose",
@@ -57,33 +48,62 @@ def list_layouts(context: Any, param: Any, value: Any) -> None:
     help="The current user's home directory. Reads from the HOME environment variable"
     + " by default.",
 )
-# https://click.palletsprojects.com/en/8.0.x/options/#callbacks-and-eager-options
-@click.option(
-    "-l",
-    "--list-layouts",
-    is_flag=True,
-    callback=list_layouts,
-    expose_value=False,
-    is_eager=True,
-    help="List available layouts and exit.",
-)
-@click.argument("layout_name")
+@click.pass_context
 @click.version_option(version=magic_tiler.__version__)
 def main(
-    verbosity_level: int, xdg_config_home_dir: str, user_home_dir: str, layout_name: str
+    context: click.Context,
+    verbosity_level: int,
+    xdg_config_home_dir: str,
+    user_home_dir: str,
 ) -> None:
-    """Create the IDE registered at LAYOUT_NAME in the configuration file."""
+    """todo: write me"""
+    # ensure that ctx.obj exists and is a dict (in case `cli()` is called outside of
+    # the python entrypoint)
+    context.ensure_object(dict)
+    # cast the object to Dict and then ignore the error that tells us we can't
+    # cast to Dict. We totally can! We just don't control the `click` source code,
+    # so `context.obj` will always be typed as Optional[Any] even if we make sure that
+    # it's a Dict :(
+    context.obj: Dict[str, Any]  # type: ignore[misc]
+
     log_level = VERBOSITY_LOG_LEVELS[verbosity_level]
     logging.basicConfig(level=log_level)
     logging.info(f"Log level set to {log_level}")
     sys.tracebacklimit = verbosity_level
     env = dtos.Env(home=user_home_dir, xdg_config_home=xdg_config_home_dir)
-    config_reader = configs.TomlConfig(filestore.LocalFilestore(), env=env)
-    parser = config_parser.ConfigParser(config_reader, tree.TreeFactory())
+    context.obj["config_reader"] = configs.TomlConfig(
+        filestore.LocalFilestore(), env=env
+    )
+    context.obj["env"] = env
+
+
+@main.command()
+@click.argument("layout_name")
+@click.pass_context
+def open(context: click.Context, layout_name: str) -> None:
+    """Open the IDE of your choice"""
+    context.obj: Dict[str, Any]  # type: ignore[misc]
+    parser = config_parser.ConfigParser(
+        context.obj["config_reader"], tree.TreeFactory()
+    )
     window_manager = sway.Sway()
     layout = layouts.LayoutManager(parser, window_manager)
-    application = MagicTiler(env, layout, verbosity_level)
+    application = MagicTiler(context.obj["env"], layout)
     application.run(layout_name)
+
+
+# I want to handle this with an "eager option", but we wouldn't be able to retrieve the
+# context from the environment variables without writing a lot more custom code
+# so it makes more sense just to use groups and subcommands
+#
+# https://click.palletsprojects.com/en/8.0.x/options/?highlight=eager#callbacks-and-eager-options
+@main.command()
+@click.pass_context
+def list_layouts(context: click.Context) -> None:
+    """List all available layouts"""
+    context.obj: Dict[str, Any]  # type: ignore[misc]
+    logging.debug(f'env: {context.obj["env"]}')
+    click.echo("these are your layouts")
 
 
 class MagicTiler(object):
@@ -93,7 +113,6 @@ class MagicTiler(object):
         self,
         env: dtos.Env,
         layout: layouts.LayoutManager,
-        verbosity_level: int,
     ) -> None:
         self._layout = layout
         logging.debug(f"Env is {env}")

--- a/src/magic_tiler/magic_tiler.py
+++ b/src/magic_tiler/magic_tiler.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+from typing import Any
 
 import click
 
@@ -24,6 +25,15 @@ VERBOSITY_LOG_LEVELS = {
 # open windows or run commands? maybe a fake supbrocess runner?
 
 
+# these types can be Any because this function declaration was lifted from the docs
+def list_layouts(context: Any, param: Any, value: Any) -> None:
+    """Callback function which lists all available layouts"""
+    if not value or context.resilient_parsing:
+        return
+    click.echo("these are your layouts")
+    context.exit()
+
+
 @click.command()
 @click.option(
     "-v",
@@ -46,6 +56,16 @@ VERBOSITY_LOG_LEVELS = {
     envvar="HOME",
     help="The current user's home directory. Reads from the HOME environment variable"
     + " by default.",
+)
+# https://click.palletsprojects.com/en/8.0.x/options/#callbacks-and-eager-options
+@click.option(
+    "-l",
+    "--list-layouts",
+    is_flag=True,
+    callback=list_layouts,
+    expose_value=False,
+    is_eager=True,
+    help="List available layouts and exit.",
 )
 @click.argument("layout_name")
 @click.version_option(version=magic_tiler.__version__)

--- a/src/magic_tiler/magic_tiler.py
+++ b/src/magic_tiler/magic_tiler.py
@@ -103,7 +103,9 @@ def list_layouts(context: click.Context) -> None:
     """List all available layouts"""
     context.obj: Dict[str, Any]  # type: ignore[misc]
     logging.debug(f'env: {context.obj["env"]}')
-    click.echo("these are your layouts")
+    for entry, details in context.obj["config_reader"].to_dict().items():
+        if "is_layout" in details:
+            click.secho(entry, fg="blue")
 
 
 class MagicTiler(object):

--- a/src/magic_tiler/utils/config_parser.py
+++ b/src/magic_tiler/utils/config_parser.py
@@ -25,11 +25,7 @@ class ConfigParser(interfaces.ConfigParserInterface):
                     )
                 self._validate_window(definition_name, definition_body)
                 seen_marks.add(definition_body["mark"])
-            elif (
-                "split" in definition_body
-                and "children" in definition_body
-                and "sizes" in definition_body
-            ):
+            elif "children" in definition_body:
                 self._validate_section(definition_name, definition_body)
             else:
                 logging.error(definition_body)
@@ -40,8 +36,18 @@ class ConfigParser(interfaces.ConfigParserInterface):
             raise RuntimeError("Window must only define command and mark")
 
     def _validate_section(self, definition_name: str, definition_body: Dict) -> None:
-        if len(definition_body) != 3:
-            raise RuntimeError("Section must only define split, children, and sizes")
+        keys = set(definition_body.keys())
+        if not {"split", "children", "sizes"}.issubset(keys):
+            raise RuntimeError(
+                f"Section must define split, children, and sizes. keys defined: {keys}"
+            )
+        allowed_keys = {"split", "children", "sizes", "is_layout"}
+        extra_keys = keys - allowed_keys
+        if len(extra_keys) > 0:
+            raise RuntimeError(
+                f"Section must only define these keys: {allowed_keys}. extra keys"
+                + f" defined: {extra_keys}"
+            )
         for child in definition_body["children"]:
             if child not in self._layout_definitions:
                 raise RuntimeError(

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -190,6 +190,19 @@ validation_test_cases = [
         expected_error_class=RuntimeError,
         layout_name="ide",
     ),
+    # invalid field in section
+    ConfigParserExceptionTestCase(
+        config_dict={
+            "ide": {
+                "split": "horizontal",
+                "children": ["a", "b"],
+                "sizes": [1, 1],
+                "woops": "idk",
+            }
+        },
+        expected_error_class=RuntimeError,
+        layout_name="ide",
+    ),
     ConfigParserExceptionTestCase(
         config_dict={
             "ide": {
@@ -371,6 +384,7 @@ def test_parser_validation_happy_path():
                 "split": "horizontal",
                 "children": ["left window", "right window"],
                 "sizes": [50, 50],
+                "is_layout": True,
             },
             "left window": {
                 "command": 'alacritty -e sh -c "echo left window!"',

--- a/tests/test_magic_tiler.py
+++ b/tests/test_magic_tiler.py
@@ -115,4 +115,9 @@ def test_run():
     layout.spawn_windows.assert_called_once_with()
 
 
+def test_list_layouts(click_runner):
+    result = click_runner.invoke(magic_tiler.main, ["-l"])
+    assert "these are your layouts" in result.output
+
+
 # TODO: add integration tests where we fail due to invalid config files

--- a/tests/test_magic_tiler.py
+++ b/tests/test_magic_tiler.py
@@ -27,6 +27,11 @@ def MockLayoutManager(mocker):
     return mocker.patch("magic_tiler.utils.layouts.LayoutManager")
 
 
+@pytest.fixture
+def MockFilestore(mocker):
+    return mocker.patch("magic_tiler.utils.filestore.LocalFilestore")
+
+
 # how do we even run an end-to-end test?? a sandboxed vm that runs a window manager?
 @pytest.mark.skip
 @pytest.mark.e2e
@@ -86,6 +91,7 @@ def test_successful_script(
     MockMagicTiler,
     MockConfig,
     MockLayoutManager,
+    MockFilestore,
     test_parameters,
 ):
     """Verify that we're setting up dependencies and calling MagicTiler correctly"""
@@ -96,6 +102,9 @@ def test_successful_script(
     )
     assert result.exit_code == 0, result.exception
     assert "" == result.output, result.exception
+    MockConfig.assert_called_once_with(
+        MockFilestore(), env=test_parameters.expected_parsed_env
+    )
     MockMagicTiler.assert_called_once_with(
         test_parameters.expected_parsed_env, MockLayoutManager()
     )


### PR DESCRIPTION
Add a subcommand to print out all of the available layout names
- Add the is_layout field to the config
- Add eager callback flag for listing available layouts
- Add error codes to mypy
- Rewrite commands as click groups instead of eager options
- Add mock filestore
- Remove dummy code and write layout names to stdout!
